### PR TITLE
Add Enabled state for Transition and switch to shared_timed_mutex to …

### DIFF
--- a/PTN_Engine/PTN_Engine/PTN_EngineImp.cpp
+++ b/PTN_Engine/PTN_Engine/PTN_EngineImp.cpp
@@ -2,6 +2,7 @@
  * This file is part of PTN Engine
  *
  * Copyright (c) 2017 Eduardo Valgôde
+ * Copyright (c) 2021 Kale Evans
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,13 +40,13 @@ PTN_Engine::PTN_EngineImp::~PTN_EngineImp()
 }
 
 void PTN_Engine::PTN_EngineImp::createTransition(const vector<string> &activationPlaces,
-												 const vector<size_t> &activationWeights,
-												 const vector<string> &destinationPlaces,
-												 const vector<size_t> &destinationWeights,
-												 const vector<string> &inhibitorPlaces,
-												 const vector<ConditionFunction> &additionalConditions)
+                                                 const vector<size_t> &activationWeights,
+                                                 const vector<string> &destinationPlaces,
+                                                 const vector<size_t> &destinationWeights,
+                                                 const vector<string> &inhibitorPlaces,
+                                                 const vector<ConditionFunction> &additionalConditions)
 {
-    std::shared_lock<std::shared_timed_mutex> guard(m_mutex);
+	unique_lock<shared_timed_mutex> guard(m_mutex);
 	createTransitionImp(activationPlaces, activationWeights, destinationPlaces, destinationWeights,
 						inhibitorPlaces, createAnonymousConditions(additionalConditions));
 }
@@ -69,23 +70,23 @@ const vector<pair<string, ConditionFunction>> &additionalConditions)
 }
 
 void PTN_Engine::PTN_EngineImp::createTransition(const vector<string> &activationPlaces,
-												 const vector<size_t> &activationWeights,
-												 const vector<string> &destinationPlaces,
-												 const vector<size_t> &destinationWeights,
-												 const vector<string> &inhibitorPlaces,
-												 const vector<string> &additionalConditions)
+                                                 const vector<size_t> &activationWeights,
+                                                 const vector<string> &destinationPlaces,
+                                                 const vector<size_t> &destinationWeights,
+                                                 const vector<string> &inhibitorPlaces,
+                                                 const vector<string> &additionalConditions)
 {
-    std::shared_lock<std::shared_timed_mutex> guard(m_mutex);
+	unique_lock<shared_timed_mutex> guard(m_mutex);
 	createTransitionImp(activationPlaces, activationWeights, destinationPlaces, destinationWeights,
 						inhibitorPlaces, getConditionFunctions(additionalConditions));
 }
 
 void PTN_Engine::PTN_EngineImp::createTransitionImp(const vector<string> &activationPlaces,
-													const vector<size_t> &activationWeights,
-													const vector<string> &destinationPlaces,
-													const vector<size_t> &destinationWeights,
-													const vector<string> &inhibitorPlaces,
-													const vector<string> &additionalConditions)
+                                                    const vector<size_t> &activationWeights,
+                                                    const vector<string> &destinationPlaces,
+                                                    const vector<size_t> &destinationWeights,
+                                                    const vector<string> &inhibitorPlaces,
+                                                    const vector<string> &additionalConditions)
 {
 	createTransitionImp(activationPlaces, activationWeights, destinationPlaces, destinationWeights,
 						inhibitorPlaces, getConditionFunctions(additionalConditions));
@@ -98,7 +99,7 @@ vector<Transition *> PTN_Engine::PTN_EngineImp::collectEnabledTransitionsRandoml
 	{
 		if (transition.isEnabled())
 		{
-            enabledTransitions.push_back(&transition);
+			enabledTransitions.push_back(&transition);
 		}
 	}
 	random_shuffle(enabledTransitions.begin(), enabledTransitions.end());
@@ -106,20 +107,20 @@ vector<Transition *> PTN_Engine::PTN_EngineImp::collectEnabledTransitionsRandoml
 }
 
 void PTN_Engine::PTN_EngineImp::createPlace(const string &name,
-											const size_t initialNumberOfTokens,
-											ActionFunction onEnterAction,
-											ActionFunction onExitAction,
-											const bool input)
+                                            const size_t initialNumberOfTokens,
+                                            ActionFunction onEnterAction,
+                                            ActionFunction onExitAction,
+                                            const bool input)
 {
-    std::shared_lock<std::shared_timed_mutex> guard(m_mutex);
+	unique_lock<shared_timed_mutex> guard(m_mutex);
 	createPlaceImp(name, initialNumberOfTokens, onEnterAction, onExitAction, input);
 }
 
 void PTN_Engine::PTN_EngineImp::createPlaceImp(const string &name,
-											   const size_t initialNumberOfTokens,
-											   ActionFunction onEnterAction,
-											   ActionFunction onExitAction,
-											   const bool input)
+                                               const size_t initialNumberOfTokens,
+                                               ActionFunction onEnterAction,
+                                               ActionFunction onExitAction,
+                                               const bool input)
 {
 	if (m_places.find(name) != m_places.end())
 	{
@@ -136,20 +137,20 @@ void PTN_Engine::PTN_EngineImp::createPlaceImp(const string &name,
 }
 
 void PTN_Engine::PTN_EngineImp::createPlaceStr(const string &name,
-											   const size_t initialNumberOfTokens,
-											   const string &onEnterAction,
-											   const string &onExitAction,
-											   const bool input)
+                                               const size_t initialNumberOfTokens,
+                                               const string &onEnterAction,
+                                               const string &onExitAction,
+                                               const bool input)
 {
-    std::shared_lock<std::shared_timed_mutex> guard(m_mutex);
+	unique_lock<shared_timed_mutex> guard(m_mutex);
 	createPlaceStrImp(name, initialNumberOfTokens, onEnterAction, onExitAction, input);
 }
 
 void PTN_Engine::PTN_EngineImp::createPlaceStrImp(const string &name,
-												  const size_t initialNumberOfTokens,
-												  const string &onEnterActionName,
-												  const string &onExitActionName,
-												  const bool input)
+                                                  const size_t initialNumberOfTokens,
+                                                  const string &onEnterActionName,
+                                                  const string &onExitActionName,
+                                                  const bool input)
 {
 	ActionFunction onEnterAction = getActionFunction(onEnterActionName);
 	ActionFunction onExitAction = getActionFunction(onEnterActionName);
@@ -171,7 +172,7 @@ void PTN_Engine::PTN_EngineImp::createPlaceStrImp(const string &name,
 
 void PTN_Engine::PTN_EngineImp::registerAction(const string &name, ActionFunction action)
 {
-    std::shared_lock<std::shared_timed_mutex> guard(m_mutex);
+	unique_lock<shared_timed_mutex> guard(m_mutex);
 	if (name.empty())
 	{
 		throw InvalidFunctionNameException(name);
@@ -188,7 +189,7 @@ void PTN_Engine::PTN_EngineImp::registerAction(const string &name, ActionFunctio
 
 void PTN_Engine::PTN_EngineImp::registerCondition(const string &name, ConditionFunction condition)
 {
-    std::shared_lock<std::shared_timed_mutex> guard(m_mutex);
+	unique_lock<shared_timed_mutex> guard(m_mutex);
 	if (name.empty())
 	{
 		throw InvalidFunctionNameException(name);
@@ -205,7 +206,7 @@ void PTN_Engine::PTN_EngineImp::registerCondition(const string &name, ConditionF
 
 void PTN_Engine::PTN_EngineImp::execute(const bool log, ostream &o)
 {
-    std::shared_lock<std::shared_timed_mutex> guard(m_mutex);
+	unique_lock<shared_timed_mutex> guard(m_mutex);
 	m_stop = false;
 	bool transitionFired;
 
@@ -283,7 +284,7 @@ PTN_Engine::PTN_EngineImp::getConditionFunctions(const vector<string> &names) co
 
 size_t PTN_Engine::PTN_EngineImp::getNumberOfTokens(const string &place) const
 {
-    std::shared_lock<std::shared_timed_mutex> guard(m_mutex);
+	shared_lock<shared_timed_mutex> guard(m_mutex);
 	if (m_places.find(place) == m_places.end())
 	{
 		throw InvalidNameException(place);
@@ -293,7 +294,7 @@ size_t PTN_Engine::PTN_EngineImp::getNumberOfTokens(const string &place) const
 
 void PTN_Engine::PTN_EngineImp::incrementInputPlace(const string &place)
 {
-    std::shared_lock<std::shared_timed_mutex> guard(m_mutex);
+	unique_lock<shared_timed_mutex> guard(m_mutex);
 
 	if (m_places.find(place) == m_places.end())
 	{
@@ -324,7 +325,7 @@ vector<WeakPtrPlace> PTN_Engine::PTN_EngineImp::getPlacesFromNames(const vector<
 
 void PTN_Engine::PTN_EngineImp::export_(IExporter &exporter) const
 {
-    std::shared_lock<std::shared_timed_mutex> guard(m_mutex);
+	shared_lock<shared_timed_mutex> guard(m_mutex);
 	exportPlaces(exporter);
 	exportTransitions(exporter);
 }
@@ -398,7 +399,7 @@ void PTN_Engine::PTN_EngineImp::exportTransitions(IExporter &exporter) const
 
 void PTN_Engine::PTN_EngineImp::import(const IImporter &importer)
 {
-    std::shared_lock<std::shared_timed_mutex> guard(m_mutex);
+	unique_lock<shared_timed_mutex> guard(m_mutex);
 	// TODO: Not exception safe, maybe this should go to a constructor instead.
 	clearNet();
 

--- a/PTN_Engine/PTN_Engine/PTN_EngineImp.h
+++ b/PTN_Engine/PTN_Engine/PTN_EngineImp.h
@@ -22,9 +22,9 @@
 #include "PTN_Engine/PTN_Exception.h"
 #include <iostream>
 #include <memory>
-#include <mutex>
 #include <unordered_map>
 #include <vector>
+#include <shared_mutex>
 
 namespace ptne
 {
@@ -238,9 +238,8 @@ public:
 private:
 	/*!
 	 * Shared mutex to synchronize API calls, allowing simultaneous reads (readers-writer lock).
-	 * Replace the normal mutex for a shared mutex once GCC supports it.
 	 */
-	mutable std::mutex m_mutex;
+	mutable std::shared_timed_mutex m_mutex;
 
 	/*!
 	 * Clear the token counter from all input places.
@@ -264,10 +263,10 @@ private:
 	getConditionFunctions(const std::vector<std::string> &names) const;
 
 	/*!
-	 * Collects and randomizes the order of all active transitions.
-	 * \return Vector of unique pointers to active transitions.
+	 * Collects and randomizes the order of all enabled transitions.
+	 * \return Vector of unique pointers to enabled transitions.
 	 */
-	std::vector<Transition *> collectActiveTransitionsRandomly();
+	std::vector<Transition *> collectEnabledTransitionsRandomly();
 
 	/*!
 	 *

--- a/PTN_Engine/PTN_Engine/PTN_EngineImp.h
+++ b/PTN_Engine/PTN_Engine/PTN_EngineImp.h
@@ -2,6 +2,7 @@
  * This file is part of PTN Engine
  *
  * Copyright (c) 2017 Eduardo Valgôde
+ * Copyright (c) 2021 Kale Evans
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,9 +23,9 @@
 #include "PTN_Engine/PTN_Exception.h"
 #include <iostream>
 #include <memory>
+#include <shared_mutex>
 #include <unordered_map>
 #include <vector>
-#include <shared_mutex>
 
 namespace ptne
 {

--- a/PTN_Engine/PTN_Engine/Transition.cpp
+++ b/PTN_Engine/PTN_Engine/Transition.cpp
@@ -97,24 +97,25 @@ bool Transition::execute()
 	return true;
 }
 
+bool Transition::isEnabled() const
+{
+    if (!checkInhibitorPlaces())
+    {
+        return false;
+    }
+
+    if (!checkActivationPlaces())
+    {
+        return false;
+    }
+
+    return true;
+}
+
 bool Transition::isActive() const
 {
-	if (!checkInhibitorPlaces())
-	{
-		return false;
-	}
 
-	if (!checkActivationPlaces())
-	{
-		return false;
-	}
-
-	if (!checkAdditionalConditions())
-	{
-		return false;
-	}
-
-	return true;
+	return isEnabled() && checkAdditionalConditions();
 }
 
 vector<tuple<Transition::WeakPtrPlace, size_t>> Transition::getActivationPlaces() const

--- a/PTN_Engine/PTN_Engine/Transition.cpp
+++ b/PTN_Engine/PTN_Engine/Transition.cpp
@@ -2,6 +2,7 @@
  * This file is part of PTN Engine
  *
  * Copyright (c) 2017 Eduardo Valgôde
+ * Copyright (c) 2021 Kale Evans
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +32,7 @@ Transition::Transition(const vector<WeakPtrPlace> &activationPlaces,
                        const vector<WeakPtrPlace> &destinationPlaces,
                        const vector<size_t> &destinationWeights,
                        const vector<WeakPtrPlace> &inhibitorPlaces,
-					   const vector<std::pair<std::string, ConditionFunction>> &additionalActivationConditions)
+                       const vector<std::pair<std::string, ConditionFunction>> &additionalActivationConditions)
 : m_additionalActivationConditions{ additionalActivationConditions }
 , m_inhibitorPlaces(inhibitorPlaces)
 {
@@ -99,22 +100,21 @@ bool Transition::execute()
 
 bool Transition::isEnabled() const
 {
-    if (!checkInhibitorPlaces())
-    {
-        return false;
-    }
+	if (!checkInhibitorPlaces())
+	{
+		return false;
+	}
 
-    if (!checkActivationPlaces())
-    {
-        return false;
-    }
+	if (!checkActivationPlaces())
+	{
+		return false;
+	}
 
-    return true;
+	return true;
 }
 
 bool Transition::isActive() const
 {
-
 	return isEnabled() && checkAdditionalConditions();
 }
 

--- a/PTN_Engine/PTN_Engine/Transition.h
+++ b/PTN_Engine/PTN_Engine/Transition.h
@@ -2,6 +2,7 @@
  * This file is part of PTN Engine
  *
  * Copyright (c) 2017 Eduardo Valgôde
+ * Copyright (c) 2021 Kale Evans
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,11 +74,11 @@ public:
 	 */
 	bool isActive() const;
 
-    /*!
-     * Evaluates if the transition can attempt to be fired.
-     * \return True if can attepmted to be fired, false if it cannot.
-     */
-    bool isEnabled() const;
+	/*!
+	 * Evaluates if the transition can attempt to be fired.
+	 * \return True if can attepmted to be fired, false if it cannot.
+	 */
+	bool isEnabled() const;
 
 	std::vector<std::tuple<WeakPtrPlace, size_t>> getActivationPlaces() const;
 

--- a/PTN_Engine/PTN_Engine/Transition.h
+++ b/PTN_Engine/PTN_Engine/Transition.h
@@ -73,6 +73,12 @@ public:
 	 */
 	bool isActive() const;
 
+    /*!
+     * Evaluates if the transition can attempt to be fired.
+     * \return True if can attepmted to be fired, false if it cannot.
+     */
+    bool isEnabled() const;
+
 	std::vector<std::tuple<WeakPtrPlace, size_t>> getActivationPlaces() const;
 
 	std::vector<std::tuple<WeakPtrPlace, size_t>> getDestinationPlaces() const;

--- a/Tests/BlackBoxTests/Fixtures/FixturePetriNet.h
+++ b/Tests/BlackBoxTests/Fixtures/FixturePetriNet.h
@@ -68,11 +68,11 @@ public:
 	 */
 	void testInhibitedState(const size_t expectedTokens[s_numberOfInhibitedNetPlaces]);
 
-	/*!
-	 *
-	 *
-	 */
+	//! Have multiple threads incrementing a place concurrently
 	void testThreadSafety();
+
+	//! Test additional activation conditions
+	void testAdditionalActivationConditions();
 
 	//! Controller containing the PTN Engine net.
 	std::shared_ptr<Dispatcher> m_dispatcher;

--- a/Tests/BlackBoxTests/Mocks/Simple/SimpleController.cpp
+++ b/Tests/BlackBoxTests/Mocks/Simple/SimpleController.cpp
@@ -42,16 +42,15 @@ void SimpleController::doSomethingConcurrently(const size_t numberOfThreads)
 		}
 	};
 
-	vector<future<void>> tasks;
+	vector<thread> threads;
 	for (size_t i = 0; i < numberOfThreads; ++i)
 	{
-		auto fut = async(launch::async, f);
-		tasks.push_back(move(fut));
+		threads.emplace_back(thread(f));
 	}
 
-	for (auto &task : tasks)
+	for (auto &t : threads)
 	{
-		task.wait();
+		t.join();
 	}
 }
 

--- a/Tests/BlackBoxTests/Tests/TestPetriNet.cpp
+++ b/Tests/BlackBoxTests/Tests/TestPetriNet.cpp
@@ -148,3 +148,8 @@ TEST_F(F2, AlreadyRegisteredMethods)
 {
 	testRepeatedRegisteredMethods();
 }
+
+TEST_F(FixturePetriNet, AdditionalActivationConditions)
+{
+	testAdditionalActivationConditions();
+}

--- a/Tests/WhiteBoxTests/Fixtures/FixtureTestPlace.cpp
+++ b/Tests/WhiteBoxTests/Fixtures/FixtureTestPlace.cpp
@@ -21,7 +21,7 @@
 using namespace ptne;
 
 FixtureTestPlace::FixtureTestPlace()
-: m_controller(std::make_shared<Controller>(Controller{}))
+: m_controller(std::make_shared<Controller>())
 , m_place(size_t(0), std::bind(&Controller::onEnter, m_controller), std::bind(&Controller::onExit, m_controller))
 {
 }

--- a/Tests/WhiteBoxTests/Fixtures/FixtureTestTransition.cpp
+++ b/Tests/WhiteBoxTests/Fixtures/FixtureTestTransition.cpp
@@ -22,7 +22,7 @@ using namespace ptne;
 using namespace std;
 
 FixtureTestTransition::FixtureTestTransition()
-: m_controller{ make_shared<Controller>(Controller{}) }
+: m_controller{ make_shared<Controller>() }
 {
 }
 
@@ -125,7 +125,7 @@ vector<weak_ptr<Place>> FixtureTestTransition::createPlaceWPtrs(const vector<sha
 {
 	// Create input places
 	vector<weak_ptr<Place>> wPtrPlaces;
-	for (shared_ptr<Place> spPlace : places)
+	for (const shared_ptr<Place> &spPlace : places)
 	{
 		wPtrPlaces.push_back(weak_ptr<Place>(spPlace));
 	}

--- a/Tests/WhiteBoxTests/Mocks/Controller.cpp
+++ b/Tests/WhiteBoxTests/Mocks/Controller.cpp
@@ -19,9 +19,10 @@
 #include "Mocks/Controller.h"
 
 Controller::Controller()
-: m_enterCounter{ 0 }
-, m_exitCounter{ 0 }
-, m_canFire{ true }
+	: m_activationConditionCallCounter(0)
+	, m_enterCounter(0)
+	, m_exitCounter(0)
+	, m_canFire(true)
 {
 }
 
@@ -47,10 +48,16 @@ size_t Controller::getExitCounter() const
 
 bool Controller::activationCondition() const
 {
+	++m_activationConditionCallCounter;
 	return m_canFire;
 }
 
 void Controller::setFireCondition(const bool canFire)
 {
 	m_canFire = canFire;
+}
+
+size_t Controller::activationConditionCallCounter() const
+{
+	return m_activationConditionCallCounter;
 }

--- a/Tests/WhiteBoxTests/Mocks/Controller.h
+++ b/Tests/WhiteBoxTests/Mocks/Controller.h
@@ -47,7 +47,13 @@ public:
 	//! Set if the activation condition should return true or false.
 	void setFireCondition(const bool);
 
+	//! Get the count of calls of the activation condition
+	size_t activationConditionCallCounter() const;
+
 private:
+	//! Activation condition call counter
+	mutable size_t m_activationConditionCallCounter;
+
 	//! Counter of times entered.
 	size_t m_enterCounter;
 

--- a/Tests/WhiteBoxTests/Tests/TestTransition.cpp
+++ b/Tests/WhiteBoxTests/Tests/TestTransition.cpp
@@ -35,9 +35,10 @@ TEST_F(FixtureTestTransition, T1)
 
 	createTransition(inputTokens, outputTokens, expectedInputTokens, expectedOutputTokens, conditions,
 					 expectedFireResult);
+	EXPECT_EQ(1, m_controller->activationConditionCallCounter());
 }
 
-TEST_F(FixtureTestTransition, T2)
+ TEST_F(FixtureTestTransition, T2)
 {
 	vector<size_t> inputTokens{ 1, 0, 1 };
 	vector<size_t> expectedInputTokens{ 1, 0, 1 };
@@ -48,9 +49,11 @@ TEST_F(FixtureTestTransition, T2)
 
 	createTransition(inputTokens, outputTokens, expectedInputTokens, expectedOutputTokens, conditions,
 					 expectedFireResult);
+
+	EXPECT_EQ(0, m_controller->activationConditionCallCounter());
 }
 
-TEST_F(FixtureTestTransition, T3)
+ TEST_F(FixtureTestTransition, T3)
 {
 	vector<size_t> inputTokens{ 1, 1, 1 };
 	vector<size_t> expectedInputTokens{ 1, 1, 1 };
@@ -62,6 +65,8 @@ TEST_F(FixtureTestTransition, T3)
 
 	createTransition(inputTokens, outputTokens, expectedInputTokens, expectedOutputTokens, conditions,
 					 expectedFireResult);
+
+	EXPECT_EQ(1, m_controller->activationConditionCallCounter());
 }
 
 TEST_F(FixtureTestTransition, T_Weights)
@@ -86,7 +91,6 @@ TEST_F(FixtureTestTransition, T_ZeroValueWeightException)
 	vector<size_t> outputTokens{ 0 };
 	vector<size_t> outputWeights{ 0 };
 	VectorOfConditions conditions{};
-	bool expectedFireResult = true;
 
 	vector<shared_ptr<Place>> inputPlaces = createPlaces(inputTokens);
 	vector<weak_ptr<Place>> wInputPlaces = createPlaceWPtrs(inputPlaces);
@@ -105,7 +109,6 @@ TEST_F(FixtureTestTransition, T_ActivationWeightDimensionException)
 	vector<size_t> outputTokens{ 0 };
 	vector<size_t> outputWeights{ 1 };
 	VectorOfConditions conditions{};
-	bool expectedFireResult = true;
 
 	vector<shared_ptr<Place>> inputPlaces = createPlaces(inputTokens);
 	vector<weak_ptr<Place>> wInputPlaces = createPlaceWPtrs(inputPlaces);
@@ -124,7 +127,6 @@ TEST_F(FixtureTestTransition, T_DestinationWeightDimensionException)
 	vector<size_t> outputTokens{ 0 };
 	vector<size_t> outputWeights{ 1, 5 };
 	VectorOfConditions conditions{};
-	bool expectedFireResult = true;
 
 	vector<shared_ptr<Place>> inputPlaces = createPlaces(inputTokens);
 	vector<weak_ptr<Place>> wInputPlaces = createPlaceWPtrs(inputPlaces);
@@ -143,7 +145,6 @@ TEST_F(FixtureTestTransition, T_ActivationPlaceRepetitionException)
 	vector<size_t> outputTokens{ 1, 2 };
 	vector<size_t> outputWeights{ 1, 5 };
 	VectorOfConditions conditions{};
-	bool expectedFireResult = true;
 
 	vector<shared_ptr<Place>> inputPlaces = createPlaces(inputTokens);
 	vector<weak_ptr<Place>> wInputPlaces = createPlaceWPtrs(inputPlaces);
@@ -163,7 +164,6 @@ TEST_F(FixtureTestTransition, T_DestinationPlaceRepetitionException)
 	vector<size_t> outputTokens{ 1, 2 };
 	vector<size_t> outputWeights{ 1, 5, 3 };
 	VectorOfConditions conditions{};
-	bool expectedFireResult = true;
 
 	vector<shared_ptr<Place>> inputPlaces = createPlaces(inputTokens);
 	vector<weak_ptr<Place>> wInputPlaces = createPlaceWPtrs(inputPlaces);


### PR DESCRIPTION
Two changes requested here:

1. Adds the concept of a transition being `Enabled`. A Transition is Enabled when:
   a. All of its input places have the expected minimum required tokens.
   b. When there are no inhibitor places who's place prevent that transition from firing.

Then a Transition is `Active` when it is Enabled and all of its conditions return true. 

This helps prevent evaluation of the conditions twice to determine whether or not to fire a transition. i.e we check if the transition is enabled, and if so, we attempt to execute the transition. This will of course only execute if the conditions also return true. 

2. Switches to `std::shared_lock<std::shared_timed_mutex>` from unique_lock<mutex>. This allows for the use of C++ Lambdas for actions that execute on enter/exit of places. Without use of shared_timed_mutex, use of lambdas results in a deadlock on Action execution when accessing members of the net. This is useful when you want to do actions based on some state of the net itself, such as number of tokens at an input place, or in general for any actions that require additional anylysis of the net. 

Example below where we use the number of Tokens at a Place 'FetchConfig' as it could be used for exponential backoff. 

Ex:

    createPlace(FetchConfig, 0, {[this, &my_process](void){
        my_process->FetchConfig(getNumberOfTokens(FetchConfig));
    }});

It looks like from your comment, you wanted to switch to shared_mutexes anyway :)